### PR TITLE
fix the bug where the camera stream would not start on samsung devices

### DIFF
--- a/ar-provider-8thwall/src/xr8-provider.ts
+++ b/ar-provider-8thwall/src/xr8-provider.ts
@@ -433,10 +433,9 @@ export class XR8Provider extends ARProvider {
             });
 
             // If we successfully acquired the camera stream - we can stop it and wait until 8th Wall requests it again
-            // Update - if we don't stop it, xr8 initializes faster
-            /* stream.getTracks().forEach((track) => {
-         track.stop();
-       });*/
+            stream.getTracks().forEach((track) => {
+                track.stop();
+            });
         } catch (exception) {
             throw new Error('Camera');
         }


### PR DESCRIPTION
**Problem description:** 
Camera feed would not start on samsung devices

**Solution**
We were acquiring the camera feed manually, even before 8th Wall would try to acquire it.
After the cam feed was successfully acquired, we would just leave it handing. Then it was time for 8th Wall to do it's own `navigator.mediaDevices.getUserMedia().` it would call it with different set of parameters which would rise a `rejected` exception specifically on samsung.
Solution is to stop the manually acquired camera feed.